### PR TITLE
trivy-scan-os-only

### DIFF
--- a/main.go
+++ b/main.go
@@ -457,7 +457,7 @@ func main() {
 		}
 
 		log.Info().Msgf("Scanning container image %v for vulnerabilities of severities %v...", containerPath, severityArgument)
-		err = foundation.RunCommandWithArgsExtended(ctx, "/trivy", []string{"--cache-dir", "/trivy-cache", "image", "--severity", severityArgument, "--security-checks", "vuln", "--skip-update", "--no-progress", "--exit-code", "15", "--ignore-unfixed", "--input", tmpfile.Name()})
+		err = foundation.RunCommandWithArgsExtended(ctx, "/trivy", []string{"--cache-dir", "/trivy-cache", "image", "--severity", severityArgument, "--vuln-type", "os" , "--security-checks", "vuln", "--skip-update", "--no-progress", "--exit-code", "15", "--ignore-unfixed", "--input", tmpfile.Name()})
 
 		if err != nil {
 			log.Fatal().Msgf("The container image has vulnerabilities of severity %v! Look at https://estafette.io/usage/fixing-vulnerabilities/ to learn how to fix vulnerabilities in your image.", severityArgument)


### PR DESCRIPTION
each library framework will have to scan its own package/library vulnerabilities

https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/

e.g. for dotnet we will add smt like this in dotnet ext, each team/language should add the language specific check to their estafette package, or maybe library vulnerability check should be an opt-in function only (as estafette parameter)
```
  package-vulnerabilities:
    image: mcr.microsoft.com/dotnet/sdk:6.0
    commands:
    - dotnet list package --vulnerable --include-transitive
```